### PR TITLE
Getting a single entity by Key

### DIFF
--- a/lib/odata-query.ts
+++ b/lib/odata-query.ts
@@ -4,7 +4,7 @@ import {
     PartArgument, Predicate, QueryPart, Result,
 } from "jinqu";
 import { InlineCountInfo } from "jinqu";
-import { handleParts, ODataFuncs, PrimitiveValue, CompositeKey } from "./shared";
+import { handleParts, ODataFuncs, SingleKey, CompositeKey } from "./shared";
 
 export class ODataQuery<
     T extends object,
@@ -28,7 +28,7 @@ export class ODataQuery<
         return this.create(part) as any;
     }
 
-    public byKey(key: PrimitiveValue | CompositeKey<T>): IODataQuery<T, TExtra> {
+    public byKey(key: SingleKey | CompositeKey<T>): IODataQuery<T, TExtra> {
         const part = new QueryPart(ODataFuncs.byKey, [PartArgument.literal(key)]);
         return this.create(part);
     }
@@ -167,7 +167,7 @@ class ExpandedODataQuery<
 }
 
 export interface IODataQuery<T, TExtra = {}> extends IQueryBase {
-    byKey(key: PrimitiveValue | CompositeKey<T>): IODataQuery<T, TExtra>;
+    byKey(key: SingleKey | CompositeKey<T>): IODataQuery<T, TExtra>;
     inlineCount(value?: boolean): IODataQuery<T, TExtra & InlineCountInfo>;
     where(predicate: Predicate<T>, ...scopes): IODataQuery<T, TExtra>;
     orderBy(keySelector: Func1<T>, ...scopes): IOrderedODataQuery<T, TExtra>;

--- a/lib/odata-query.ts
+++ b/lib/odata-query.ts
@@ -74,9 +74,9 @@ export class ODataQuery<
         return this.create(part);
     }
 
-    public select<K extends keyof T>(...names: K[]): PromiseLike<Result<Array<Pick<T, K>>, TExtra>> {
+    public select<K extends keyof T>(...names: K[]): IODataQuery<Pick<T, K>, TExtra> {
         const part = new QueryPart(ODataFuncs.oDataSelect, [PartArgument.literal(names)]);
-        return this.provider.executeAsync([...this.parts, part]);
+        return this.create(part);
     }
 
     public groupBy<TKey extends object, TResult extends object>(
@@ -183,7 +183,7 @@ export interface IODataQuery<T, TExtra = {}> extends IQueryBase {
     take(count: number): IODataQuery<T, TExtra>;
     cast(ctor: Ctor<T>): IODataQuery<T, TExtra>;
 
-    select<K extends keyof T>(...names: K[]): PromiseLike<Result<Array<Pick<T, K>>, TExtra>>;
+    select<K extends keyof T>(...names: K[]): IODataQuery<Pick<T, K>, TExtra>;
     groupBy<TKey extends object, TResult extends object>(
         keySelector: Func1<T, TKey>, elementSelector?: Func1<T[] & TKey, TResult>, ...scopes: any[])
         : PromiseLike<Result<TResult[], TExtra>>;

--- a/lib/odata-query.ts
+++ b/lib/odata-query.ts
@@ -74,9 +74,9 @@ export class ODataQuery<
         return this.create(part);
     }
 
-    public select<K extends keyof T>(...names: K[]): IODataQuery<Pick<T, K>, TExtra> {
+    public select<K extends keyof T>(...names: K[]): PromiseLike<Result<Array<Pick<T, K>>, TExtra>> {
         const part = new QueryPart(ODataFuncs.oDataSelect, [PartArgument.literal(names)]);
-        return this.create(part);
+        return this.provider.executeAsync([...this.parts, part]);
     }
 
     public groupBy<TKey extends object, TResult extends object>(
@@ -183,7 +183,7 @@ export interface IODataQuery<T, TExtra = {}> extends IQueryBase {
     take(count: number): IODataQuery<T, TExtra>;
     cast(ctor: Ctor<T>): IODataQuery<T, TExtra>;
 
-    select<K extends keyof T>(...names: K[]): IODataQuery<Pick<T, K>, TExtra>;
+    select<K extends keyof T>(...names: K[]): PromiseLike<Result<Array<Pick<T, K>>, TExtra>>;
     groupBy<TKey extends object, TResult extends object>(
         keySelector: Func1<T, TKey>, elementSelector?: Func1<T[] & TKey, TResult>, ...scopes: any[])
         : PromiseLike<Result<TResult[], TExtra>>;

--- a/lib/odata-query.ts
+++ b/lib/odata-query.ts
@@ -4,7 +4,7 @@ import {
     PartArgument, Predicate, QueryPart, Result,
 } from "jinqu";
 import { InlineCountInfo } from "jinqu";
-import { handleParts, ODataFuncs, PrimitiveValue } from "./shared";
+import { handleParts, ODataFuncs, PrimitiveValue, CompositeKey } from "./shared";
 
 export class ODataQuery<
     T extends object,
@@ -28,7 +28,7 @@ export class ODataQuery<
         return this.create(part) as any;
     }
 
-    public byKey(key: PrimitiveValue): IODataQuery<T, TExtra> {
+    public byKey(key: PrimitiveValue | CompositeKey<T>): IODataQuery<T, TExtra> {
         const part = new QueryPart(ODataFuncs.byKey, [PartArgument.literal(key)]);
         return this.create(part);
     }
@@ -167,7 +167,7 @@ class ExpandedODataQuery<
 }
 
 export interface IODataQuery<T, TExtra = {}> extends IQueryBase {
-    byKey(key: PrimitiveValue): IODataQuery<T, TExtra>;
+    byKey(key: PrimitiveValue | CompositeKey<T>): IODataQuery<T, TExtra>;
     inlineCount(value?: boolean): IODataQuery<T, TExtra & InlineCountInfo>;
     where(predicate: Predicate<T>, ...scopes): IODataQuery<T, TExtra>;
     orderBy(keySelector: Func1<T>, ...scopes): IOrderedODataQuery<T, TExtra>;

--- a/lib/odata-service.ts
+++ b/lib/odata-service.ts
@@ -73,7 +73,12 @@ export class ODataService<TResponse = Response>
                     value = value.value;
                 }
                 else {
-                    delete value["@odata.context"];
+                    //delete value["@odata.context"];
+                    Object.keys(value).forEach((key: string) => {
+                        if (key && key[0] === "@") {
+                            delete value[key];    
+                        }
+                    });
                 }
 
                 if (!inlineCountEnabled && !includeResponse) {

--- a/lib/odata-service.ts
+++ b/lib/odata-service.ts
@@ -7,6 +7,7 @@ import { FetchProvider } from "jinqu-fetch";
 import { getResource } from "./decorators";
 import { ODataQuery } from "./odata-query";
 import { ODataQueryProvider } from "./odata-query-provider";
+import { ODataFuncs } from "./shared";
 
 export class ODataService<TResponse = Response>
     implements IRequestProvider<AjaxOptions>  {
@@ -30,11 +31,14 @@ export class ODataService<TResponse = Response>
 
         let includeResponse = false;
         let countPrm: QueryParameter = null;
+        let keyPrm: QueryParameter = null;
         o.params = o.params || [];
         params = params || [];
         let inlineCountEnabled = false;
         params.forEach((p) => {
-            if (p.key === QueryFunc.inlineCount) {
+            if (p.key === ODataFuncs.byKey) {
+                keyPrm = p;
+            } else if (p.key === QueryFunc.inlineCount) {
                 o.params.push({ key: "$count", value: "true" });
                 inlineCountEnabled = true;
             } else if (p.key === "$count") {
@@ -45,6 +49,14 @@ export class ODataService<TResponse = Response>
                 o.params.push(p);
             }
         });
+
+        if (keyPrm) {
+            let keyVal = null;
+            if (keyPrm.value) {
+                keyVal = typeof keyPrm.value === "string" ? "'" + keyPrm.value + "'" : keyPrm.value;
+            }
+            o.url += `(${keyVal})`;
+        }
 
         if (o.params.length) {
             o.url += "?" + o.params.map((p) => `${p.key}=${encodeURIComponent(p.value)}`).join("&");
@@ -64,13 +76,16 @@ export class ODataService<TResponse = Response>
                 if (value && value.value !== void 0) {
                     value = value.value;
                 }
+                else {
+                    delete value["@odata.context"];
+                }
 
                 if (!inlineCountEnabled && !includeResponse) {
                     return value;
                 }
 
                 return {
-                    inlineCount: inlineCountEnabled ? Number(r.value && r.value["odata.count"]) : void 0,
+                    inlineCount: inlineCountEnabled ? Number(r.value && r.value["@odata.count"]) : void 0,
                     response: includeResponse ? r.response : void 0,
                     value,
                 };

--- a/lib/odata-service.ts
+++ b/lib/odata-service.ts
@@ -51,11 +51,7 @@ export class ODataService<TResponse = Response>
         });
 
         if (keyPrm) {
-            let keyVal = null;
-            if (keyPrm.value) {
-                keyVal = typeof keyPrm.value === "string" ? "'" + keyPrm.value + "'" : keyPrm.value;
-            }
-            o.url += `(${keyVal})`;
+            o.url += `(${keyPrm.value})`;
         }
 
         if (o.params.length) {

--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -10,8 +10,11 @@ import {
     VariableExpression,
 } from "jokenizer";
 
+export type PrimitiveValue = string | number | bigint | boolean | undefined | null;
+
 export const ODataFuncs = {
     apply: "apply",
+    byKey: "byKey",
     expand: "expand",
     filter: "filter",
     oDataSelect: "oDataSelect",
@@ -50,6 +53,7 @@ export function handleParts(parts: IQueryPart[]): [QueryParameter[], AjaxOptions
     const params = {};
     const queryParams: QueryParameter[] = [];
     const expands: IQueryPart[] = [];
+    let byKey: IQueryPart;
     let inlineCount = false;
     let includeResponse = false;
     let orders: IQueryPart[] = [];
@@ -70,6 +74,8 @@ export function handleParts(parts: IQueryPart[]): [QueryParameter[], AjaxOptions
             inlineCount = true;
         } else if (part.type === AjaxFuncs.includeResponse) {
             includeResponse = true;
+        } else if (part.type === ODataFuncs.byKey) {
+            byKey = part;
         } else if (part.type === ODataFuncs.oDataSelect) {
             select = part;
         } else if (part.type === ODataFuncs.expand || part.type === ODataFuncs.thenExpand) {
@@ -86,6 +92,10 @@ export function handleParts(parts: IQueryPart[]): [QueryParameter[], AjaxOptions
         } else {
             throw new Error(`${part.type} is not supported.`);
         }
+    }
+
+    if (byKey) {
+        queryParams.push({ key: ODataFuncs.byKey, value: byKey.args[0].literal });
     }
 
     if (orders.length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jinqu-odata",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "description": "Jinqu OData implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jinqu-odata",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Jinqu OData implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jinqu-odata",
-  "version": "1.1.5",
+  "version": "1.1.3",
   "description": "Jinqu OData implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jinqu-odata",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "description": "Jinqu OData implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/fixture.ts
+++ b/test/fixture.ts
@@ -74,3 +74,7 @@ export function getCompanies(): ICompany[] {
         { id: 2, name: "Google", createDate: new Date(), deleted: false, addresses: [] },
     ];
 }
+
+export function getCompany(): ICompany {
+    return { id: 3, name: "IBM", createDate: new Date(), deleted: false, addresses: [] };
+}

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -195,9 +195,9 @@ describe("Service tests", () => {
     });
 
     it("should handle select", () => {
-        const promise = service.companies()
+        const query = service.companies()
             .select("id", "name");
-        expect(promise).to.be.fulfilled.and.eventually.be.null;
+        expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
 
         const url = provider.options.url;
         const expectedUrl = `api/Companies?$select=${encodeURIComponent("id,name")}`;

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -195,9 +195,9 @@ describe("Service tests", () => {
     });
 
     it("should handle select", () => {
-        const query = service.companies()
+        const promise = service.companies()
             .select("id", "name");
-        expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+        expect(promise).to.be.fulfilled.and.eventually.be.null;
 
         const url = provider.options.url;
         const expectedUrl = `api/Companies?$select=${encodeURIComponent("id,name")}`;

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -9,7 +9,7 @@ import "mocha";
 
 import { ODataQuery, ODataQueryProvider, ODataService } from "../index";
 import { ODataFuncs } from "../lib/shared";
-import { Company, CompanyService, Country, getCompanies, ICompany, ICountry, MockRequestProvider } from "./fixture";
+import { Company, CompanyService, Country, getCompanies, getCompany, ICompany, ICountry, MockRequestProvider } from "./fixture";
 
 chai.use(chaiAsPromised);
 
@@ -111,7 +111,7 @@ describe("Service tests", () => {
 
     it("should handle inlineCount", async () => {
         const value1 = [];
-        const result1 = { "odata.count": 100, "value": value1 };
+        const result1 = { "@odata.count": 100, "value": value1 };
         const prv1 = new MockRequestProvider(result1);
         const query1 = new CompanyService(prv1).companies().inlineCount();
         const response1 = await query1.toArrayAsync();
@@ -458,5 +458,36 @@ describe("Service tests", () => {
         const url = provider.options.url;
         const expectedUrl = `api/Companies?$filter=${encodeURIComponent("deleted eq false")}`;
         expect(url).equal(expectedUrl);
+    });
+
+    it("should handle byKey(single)", async () => {
+        const value = getCompany();
+        const result = Object.assign({}, { "@odata.context": "ctx" }, value);
+        const prv = new MockRequestProvider(result);
+        const query1 = new CompanyService(prv).companies().byKey(5);
+        const response1 = await query1.singleAsync();
+        const url1 = prv.options.url;
+        const expectedUrl1 = "api/Companies(5)";
+        expect(url1).equal(expectedUrl1);
+        expect(response1).to.deep.equal(value);
+
+        const query2 = service.companies().byKey("id5");
+        expect(query2.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+        const url2 = provider.options.url;
+        const expectedUrl2 = "api/Companies('id5')";
+        expect(url2).equal(expectedUrl2);
+    });
+    
+    it("should handle byKey({composite})", async () => {
+        const query1 = service.companies().byKey({ id: 7, name: "Microsoft" });
+        expect(query1.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+        const url1 = provider.options.url;
+        const expectedUrl1 = "api/Companies(id=7,name='Microsoft')";
+        expect(url1).equal(expectedUrl1);
+    });
+    
+    it("should throw for invalid composite key", async () => {
+        const query2 = service.companies().byKey({ id: 7 });
+        expect(() => query2.toArrayAsync()).to.throw();
     });
 });

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -472,7 +472,7 @@ describe("Service tests", () => {
         expect(response1).to.deep.equal(value);
 
         const query2 = service.companies().byKey("id5");
-        expect(query2.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+        expect(query2.singleAsync()).to.be.fulfilled.and.eventually.be.null;
         const url2 = provider.options.url;
         const expectedUrl2 = "api/Companies('id5')";
         expect(url2).equal(expectedUrl2);
@@ -480,7 +480,7 @@ describe("Service tests", () => {
     
     it("should handle byKey({composite})", async () => {
         const query1 = service.companies().byKey({ id: 7, name: "Microsoft" });
-        expect(query1.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+        expect(query1.singleAsync()).to.be.fulfilled.and.eventually.be.null;
         const url1 = provider.options.url;
         const expectedUrl1 = "api/Companies(id=7,name='Microsoft')";
         expect(url1).equal(expectedUrl1);
@@ -488,6 +488,6 @@ describe("Service tests", () => {
     
     it("should throw for invalid composite key", async () => {
         const query2 = service.companies().byKey({ id: 7 });
-        expect(() => query2.toArrayAsync()).to.throw();
+        expect(() => query2.singleAsync()).to.throw();
     });
 });


### PR DESCRIPTION
## Change list
1.  Implemented getting a single entity by single/composite key (Issue #34 ), with tests added
2.  Fixed the name of "@odata.count" property in OData result set (must begin with "@", see [OData v4](http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Representing_Multiple_Entities) and really begins in MS implementation)

## Types of changes

What types of changes are you proposing/introducing?
_Put an `x` in the boxes that apply_

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details
```
export class NorthwindContext extends ODataService {
  constructor() {  super('api/');  }

  get products(): IODataQuery<Product> { return this.createQuery<Product>('products'); }
  get orderDetails(): IODataQuery<OrderDetail> { return this.createQuery<OrderDetail>('orderDetails'); }
}

/* single key */
/* api/products(3) */
let productId: number = 3;
let product: Product = await this.context.products
  .byKey(productId)
  .singleAsync();

/* composite key */
/* api/orderDetails(orderId=10527,productId=4) */
let orderId: number = 10527, productId: number = 4;
let orderDetail: OrderDetail = await this.context.orderDetails
  .byKey({ orderId, productId })
  .singleAsync();
```
It is also possible to make byKey calls as following:
```
export class NorthwindContext extends ODataService {
...
  products(key?: number): IODataQuery<Product> {
    let query = this.createQuery<Product>('products');
    return key ? query.byKey(key) : query;
  }
}

const allProducts: Product[] = await this.context.products()
  .toArrayAsync();

let singleProduct: Product = await this.context.products(productId)
  .singleAsync();
```
PS. Using Date fields as a singke key or a part of composite one is not implemented.