### PR TITLE
select as array of members

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "configurations": [
+        {
+            "name": "Attach to Chrome",
+            "address": "localhost",
+            "port": 9222,
+            "request": "attach",
+            "type": "pwa-chrome",
+            "sourceMaps": true,
+            "timeout": 600000,
+            "restart": true,
+            "webRoot": "${workspaceFolder}",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "pathMapping": {
+                "/": "${workspaceFolder}",
+                "/base/": "${workspaceFolder}"
+            }
+        }
+    ],
+    "outFiles": [
+        //"${workspaceFolder}/dist/**/*.js"
+        "${workspaceFolder}/**/*.js"
+    ]
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,7 +26,15 @@ module.exports = function (config) {
                 "./index.ts",
                 "./lib/**/*.ts",
                 "./test/**/*.ts"
-            ]
+            ],
+            /* for debug */
+/*            bundlerOptions: {
+                sourceMap: true
+            },
+            coverageOptions: {
+                instrumentation: false
+            }
+*/
         },
 
         reporters: ["dots", "karma-typescript"],
@@ -34,5 +42,24 @@ module.exports = function (config) {
         browsers,
 
         singleRun: true
+
+        /* for debug */
+/*        browsers: ["ChromeHeadless"],
+        singleRun: false,
+        autoWatch: true,
+        customLaunchers: {
+            ChromeHeadless: {
+                base: 'Chrome',
+                flags: [
+                    //"--no-sandbox",
+                    //"--user-data-dir=/tmp/chrome-test-profile",
+                    "--disable-web-security",
+                    "--remote-debugging-address=0.0.0.0",
+                    "--remote-debugging-port=9222",
+                ],
+                debug: true,
+            }
+        }
+*/
     });
 };

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -194,9 +194,19 @@ describe("Service tests", () => {
         expect(url).equal(expectedUrl);
     });
 
-    it("should handle select", () => {
+    it("should handle select as literals", () => {
         const query = service.companies()
             .select("id", "name");
+        expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+
+        const url = provider.options.url;
+        const expectedUrl = `api/Companies?$select=${encodeURIComponent("id,name")}`;
+        expect(url).equal(expectedUrl);
+    });
+
+    it("should handle select as array of members", () => {
+        const query = service.companies()
+            .select(c => [c.id, c.name]);
         expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
 
         const url = provider.options.url;


### PR DESCRIPTION
## Change list
select() as array of model members
 
## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details
ODataQuery.select() can be also called with arrow function with an argument of model and result as array of model members:
```
const result = this.context.products()
    //.select('ProductId', 'ProductName', 'UnitPrice')
    .select(p => [p.ProductId, p.ProductName, p.UnitPrice])
    .toArrayAsync();
```
Old .select() signature with field literals is also preserved.