### PR TITLE
Chain query filters

### DIFF
--- a/lib/odata-query-provider.ts
+++ b/lib/odata-query-provider.ts
@@ -19,8 +19,21 @@ export class ODataQueryProvider<TOptions extends AjaxOptions, TResponse> impleme
     public executeAsync<T = any, TResult = T[]>(parts: IQueryPart[]): PromiseLike<TResult> {
         const [queryParams, options, ctor] = handleParts(parts);
         const promise = this.requestProvider.request<TResult>(queryParams, options);
-        return ctor
-            ? promise.then((d) => plainToClass(ctor, d))
-            : promise;
+
+        if (ctor) {
+            return promise.then((d: any) => {
+                if ((d.inlineCount !== void 0 || d.response) && d.value !== void 0) {
+                    d.value = plainToClass(ctor, d.value);
+                    return d;
+                }
+                else {
+                    return plainToClass(ctor, d);
+                }
+            })
+        }
+        else {
+            return promise;
+        }
     }
 }
+

--- a/lib/odata-query-provider.ts
+++ b/lib/odata-query-provider.ts
@@ -8,6 +8,10 @@ export class ODataQueryProvider<TOptions extends AjaxOptions, TResponse> impleme
     constructor(protected requestProvider: IRequestProvider<AjaxOptions>) {
     }
 
+    public get updateMethod(): "PATCH" | "PUT" {
+        return (this.requestProvider as any).options.updateMethod;
+    }
+
     public createQuery<T extends object>(parts?: IQueryPart[]): ODataQuery<T, TOptions, TResponse> {
         return new ODataQuery<T, TOptions, TResponse>(this, parts);
     }

--- a/lib/odata-query-provider.ts
+++ b/lib/odata-query-provider.ts
@@ -25,13 +25,11 @@ export class ODataQueryProvider<TOptions extends AjaxOptions, TResponse> impleme
                 if ((d.inlineCount !== void 0 || d.response) && d.value !== void 0) {
                     d.value = plainToClass(ctor, d.value);
                     return d;
-                }
-                else {
+                } else {
                     return plainToClass(ctor, d);
                 }
             })
-        }
-        else {
+        } else {
             return promise;
         }
     }

--- a/lib/odata-query.ts
+++ b/lib/odata-query.ts
@@ -34,6 +34,11 @@ export class ODataQuery<
         return this.create(part) as any;
     }
 
+    public setData(value: any): IODataQuery<T, TExtra> {
+        const part = new QueryPart(ODataFuncs.setData, [PartArgument.literal(value)]);
+        return this.create(part);
+    }
+
     public byKey(key: SingleKey | CompositeKey<T>): IODataQuery<T, TExtra> {
         const part = new QueryPart(ODataFuncs.byKey, [PartArgument.literal(key)]);
         return this.create(part);
@@ -134,11 +139,8 @@ export class ODataQuery<
         return new ExpandedODataQuery<T, TNav, TOptions, TResponse, TExtra>(this.provider, [...this.parts, part]);
     }
 
-    public insertAsync(entity: T, returnInserted?: boolean): PromiseLike<Result<T, TExtra>> {
-        const options: AjaxOptions = {
-            method: "POST",
-            data: entity,
-        };
+    public insertAsync(returnInserted?: boolean): PromiseLike<Result<T, TExtra>> {
+        const options: AjaxOptions = { method: "POST" };
         //if (returnInserted) {
         //    options.headers = {
         //        "prefer": "return=representation"
@@ -148,11 +150,8 @@ export class ODataQuery<
         return (this.provider as any).executeAsync([...this.parts, part]);
     }
 
-    public updateAsync(entity: T, returnUpdated?: boolean): PromiseLike<Result<T, TExtra>> {
-        const options: AjaxOptions = {
-            method: "PUT",
-            data: entity,
-        };
+    public updateAsync(returnUpdated?: boolean): PromiseLike<Result<T, TExtra>> {
+        const options: AjaxOptions = { method: "PUT" };
         if (returnUpdated) {
             options.headers = {
                 "prefer": "return=representation"
@@ -230,10 +229,11 @@ export interface IODataQuery<T, TExtra = {}> extends IQueryBase {
         keySelector: Func1<T, TKey>, elementSelector?: Func1<T[] & TKey, TResult>, ...scopes: any[])
         : PromiseLike<Result<TResult[], TExtra>>;
     count(predicate?: Predicate<T>, ...scopes): PromiseLike<Result<number, TExtra>>;
+    setData(value: any): IODataQuery<T, TExtra>;
     toArrayAsync(ctor?: Ctor<T>): PromiseLike<Result<T[], TExtra>>;
     singleAsync(ctor?: Ctor<T>): PromiseLike<Result<T, TExtra>>;
-    insertAsync(entity: T, returnInserted?: boolean): PromiseLike<Result<T, TExtra>>;
-    updateAsync(entity: T, returnUpdated?: boolean): PromiseLike<Result<T, TExtra>>;
+    insertAsync(returnInserted?: boolean): PromiseLike<Result<T, TExtra>>;
+    updateAsync(returnUpdated?: boolean): PromiseLike<Result<T, TExtra>>;
     deleteAsync(): PromiseLike<Result<void, TExtra>>;
 }
 

--- a/lib/odata-query.ts
+++ b/lib/odata-query.ts
@@ -4,7 +4,13 @@ import {
     PartArgument, Predicate, QueryPart, Result,
 } from "jinqu";
 import { InlineCountInfo } from "jinqu";
-import { handleParts, ODataFuncs, SingleKey, CompositeKey } from "./shared";
+import { handleParts, ODataFuncs } from "./shared";
+
+export type SingleKey = string | number | bigint | boolean | null;// | Date;
+//export type CompositeKey<T> = { [K in keyof T]?: T[K] extends object ? never : T[K] };
+export type CompositeKey<T> = { [P in
+    ({ [K in keyof T]: T[K] extends object ? never : K }[keyof T])
+]?: T[P] };
 
 export class ODataQuery<
     T extends object,

--- a/lib/odata-query.ts
+++ b/lib/odata-query.ts
@@ -133,6 +133,42 @@ export class ODataQuery<
     protected createExpandedQuery<TNav>(part: IQueryPart): IExpandedODataQuery<T, TNav, TExtra> {
         return new ExpandedODataQuery<T, TNav, TOptions, TResponse, TExtra>(this.provider, [...this.parts, part]);
     }
+
+    public insertAsync(entity: T, returnInserted?: boolean): PromiseLike<Result<T, TExtra>> {
+        const options: AjaxOptions = {
+            method: "POST",
+            data: entity,
+        };
+        //if (returnInserted) {
+        //    options.headers = {
+        //        "prefer": "return=representation"
+        //    };
+        //}
+        const part = new QueryPart(AjaxFuncs.options, [PartArgument.literal(options)]);
+        return (this.provider as any).executeAsync([...this.parts, part]);
+    }
+
+    public updateAsync(entity: T, returnUpdated?: boolean): PromiseLike<Result<T, TExtra>> {
+        const options: AjaxOptions = {
+            method: "PUT",
+            data: entity,
+        };
+        if (returnUpdated) {
+            options.headers = {
+                "prefer": "return=representation"
+            };
+        }
+        const part = new QueryPart(AjaxFuncs.options, [PartArgument.literal(options)]);
+        return (this.provider as any).executeAsync([...this.parts, part]);
+    }
+
+    public deleteAsync(): PromiseLike<Result<void, TExtra>> {
+        const options: AjaxOptions = {
+            method: "DELETE"
+        };
+        const part = new QueryPart(AjaxFuncs.options, [PartArgument.literal(options)]);
+        return (this.provider as any).executeAsync([...this.parts, part]);
+    }
 }
 
 // tslint:disable-next-line:max-classes-per-file
@@ -196,6 +232,9 @@ export interface IODataQuery<T, TExtra = {}> extends IQueryBase {
     count(predicate?: Predicate<T>, ...scopes): PromiseLike<Result<number, TExtra>>;
     toArrayAsync(ctor?: Ctor<T>): PromiseLike<Result<T[], TExtra>>;
     singleAsync(ctor?: Ctor<T>): PromiseLike<Result<T, TExtra>>;
+    insertAsync(entity: T, returnInserted?: boolean): PromiseLike<Result<T, TExtra>>;
+    updateAsync(entity: T, returnUpdated?: boolean): PromiseLike<Result<T, TExtra>>;
+    deleteAsync(): PromiseLike<Result<void, TExtra>>;
 }
 
 export interface IOrderedODataQuery<T, TExtra = {}> extends IODataQuery<T, TExtra> {

--- a/lib/odata-query.ts
+++ b/lib/odata-query.ts
@@ -147,18 +147,18 @@ export class ODataQuery<
         //    };
         //}
         const part = new QueryPart(AjaxFuncs.options, [PartArgument.literal(options)]);
-        return (this.provider as any).executeAsync([...this.parts, part]);
+        return (this.provider as any).executeAsync([part, ...this.parts]);
     }
 
     public updateAsync(returnUpdated?: boolean): PromiseLike<Result<T, TExtra>> {
-        const options: AjaxOptions = { method: "PUT" };
+        const options: AjaxOptions = { method: (this.provider as any).updateMethod };
         if (returnUpdated) {
             options.headers = {
                 "prefer": "return=representation"
             };
         }
         const part = new QueryPart(AjaxFuncs.options, [PartArgument.literal(options)]);
-        return (this.provider as any).executeAsync([...this.parts, part]);
+        return (this.provider as any).executeAsync([part, ...this.parts]);
     }
 
     public deleteAsync(): PromiseLike<Result<void, TExtra>> {
@@ -166,7 +166,7 @@ export class ODataQuery<
             method: "DELETE"
         };
         const part = new QueryPart(AjaxFuncs.options, [PartArgument.literal(options)]);
-        return (this.provider as any).executeAsync([...this.parts, part]);
+        return (this.provider as any).executeAsync([part, ...this.parts]);
     }
 }
 

--- a/lib/odata-service.ts
+++ b/lib/odata-service.ts
@@ -76,7 +76,7 @@ export class ODataService<TResponse = Response>
                     //delete value["@odata.context"];
                     Object.keys(value).forEach((key: string) => {
                         if (key && key[0] === "@") {
-                            delete value[key];    
+                            delete value[key];
                         }
                     });
                 }

--- a/lib/odata-service.ts
+++ b/lib/odata-service.ts
@@ -69,16 +69,17 @@ export class ODataService<TResponse = Response>
         return this.ajaxProvider.ajax(o)
             .then((r) => {
                 let value = r.value as any;
-                if (value && value.value !== void 0) {
-                    value = value.value;
-                }
-                else {
-                    //delete value["@odata.context"];
-                    Object.keys(value).forEach((key: string) => {
-                        if (key && key[0] === "@") {
-                            delete value[key];
-                        }
-                    });
+                if (value) {
+                    if (value.value !== void 0) {
+                        value = value.value;
+                    } else {
+                        //delete value["@odata.context"];
+                        Object.keys(value).forEach((key: string) => {
+                            if (key && key[0] === "@") {
+                                delete value[key];
+                            }
+                        });
+                    }
                 }
 
                 if (!inlineCountEnabled && !includeResponse) {

--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -57,11 +57,11 @@ export function handleParts(parts: IQueryPart[]): [QueryParameter[], AjaxOptions
     const params = {};
     const queryParams: QueryParameter[] = [];
     const expands: IQueryPart[] = [];
+    const filters: IQueryPart[] = [];
     let byKey: IQueryPart;
     let inlineCount = false;
     let includeResponse = false;
     let orders: IQueryPart[] = [];
-    let filters: IQueryPart[] = [];
     let select: IQueryPart;
     let apply: IQueryPart;
     let ctor: Ctor<any>;

--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -16,6 +16,7 @@ export const ODataFuncs = {
     expand: "expand",
     filter: "filter",
     oDataSelect: "oDataSelect",
+    setData: "setData",
     thenExpand: "thenExpand",
     top: "top",
 };
@@ -54,6 +55,7 @@ export function handleParts(parts: IQueryPart[]): [QueryParameter[], AjaxOptions
     const queryParams: QueryParameter[] = [];
     const expands: IQueryPart[] = [];
     const filters: IQueryPart[] = [];
+    let data: IQueryPart;
     let byKey: IQueryPart;
     let inlineCount = false;
     let includeResponse = false;
@@ -88,6 +90,8 @@ export function handleParts(parts: IQueryPart[]): [QueryParameter[], AjaxOptions
         } else if (part.type === ODataFuncs.apply) {
             ctor = null;
             apply = part;
+        } else if (part.type === ODataFuncs.setData) {
+            data = part;
         } else if (orderFuncs.indexOf(part.type) !== -1) {
             orders = [part];
         } else if (thenFuncs.indexOf(part.type) !== -1) {
@@ -187,6 +191,10 @@ export function handleParts(parts: IQueryPart[]): [QueryParameter[], AjaxOptions
         } else {
             queryParams.push({ key: "$apply", value: `groupby((${keySelector}))` });
         }
+    }
+
+    if (data) {
+        options.push({ data: data.args[0].literal });
     }
 
     return [queryParams, options, ctor];

--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -112,12 +112,10 @@ export function handleParts(parts: IQueryPart[]): [QueryParameter[], AjaxOptions
             if (typeof argVal === "object") {
                 if (Object.keys(argVal).length > 1) {
                     keyVal = Object.keys(argVal).map((key: string) => `${key}=${quoteIfString(argVal[key])}`).join(",");
-                }
-                else {
+                } else {
                     throw new Error("Composite key must have at least two properties.");
                 }
-            }
-            else {
+            } else {
                 keyVal = quoteIfString(argVal);
             }
         }

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -469,6 +469,13 @@ describe("Service tests", () => {
         result.forEach((r) => expect(r).to.be.instanceOf(Company));
     });
 
+    it("should handle cast via toArrayAsync with inlineCount", async () => {
+        const prv = new MockRequestProvider({ value: getCompanies() });
+        const svc = new ODataService("api", prv);
+        const result = await svc.createQuery<ICompany>("Companies").inlineCount().toArrayAsync(Company);
+
+        result.value.forEach((r) => expect(r).to.be.instanceOf(Company));
+    });
 
     it('should handle boolean parameters', () => {
         const query = service.companies()

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -555,12 +555,14 @@ it("should handle date literal", async () => {
         const value = getCompany();
         const result = Object.assign({}, value);
         const prv = new MockRequestProvider(result);
-        const query1 = new CompanyService(prv).companies().byKey(5);
-        const response1 = await query1.updateAsync(value);
+        const query1 = new CompanyService(prv).companies().byKey(5).setData(value);
+        const response1 = await query1.updateAsync(true);
         const url1 = prv.options.url;
         const expectedUrl1 = "api/Companies(5)";
         expect(url1).equal(expectedUrl1);
         expect(prv.options.method).equal("PUT");
+        expect(prv.options.data).equal(value);
+        expect(prv.options.headers.prefer).equal("return=representation");
         expect(response1).to.deep.equal(value);
     });
 

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -560,7 +560,7 @@ it("should handle date literal", async () => {
         const url1 = prv.options.url;
         const expectedUrl1 = "api/Companies(5)";
         expect(url1).equal(expectedUrl1);
-        expect(prv.options.method).equal("PUT");
+        expect(prv.options.method).equal("PATCH");
         expect(prv.options.data).equal(value);
         expect(prv.options.headers.prefer).equal("return=representation");
         expect(response1).to.deep.equal(value);
@@ -589,6 +589,30 @@ it("should handle date literal", async () => {
         expect(url1).equal(expectedUrl1);
         expect(prv.options.method).equal("DELETE");
         expect(response1).to.be.null; // .undefined ??
+    });
+
+    it("should handle updateAsync with PUT", async () => {
+        const query = service.createQuery<ICompany>("Companies")
+            .withOptions({ method: "PUT" });
+        expect(query.updateAsync()).to.be.fulfilled.and.eventually.be.null;
+
+        const url = provider.options.url;
+        expect(url).equal("api/Companies");
+        expect(provider.options.method).equal("PUT");
+    });
+
+    it("should handle ODataService options", async () => {
+        const svc = new ODataService({
+            baseAddress: "api",
+            ajaxProvider: provider,
+            updateMethod: "PUT"
+        });
+        const query = svc.createQuery<ICompany>("Companies");
+        expect(query.updateAsync()).to.be.fulfilled.and.eventually.be.null;
+
+        const url = provider.options.url;
+        expect(url).equal("api/Companies");
+        expect(provider.options.method).equal("PUT");
     });
 
 });

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -566,4 +566,29 @@ it("should handle date literal", async () => {
         expect(response1).to.deep.equal(value);
     });
 
+    it("should handle insertAsync", async () => {
+        const value = getCompany();
+        const result = Object.assign({}, value);
+        const prv = new MockRequestProvider(result);
+        const query1 = new CompanyService(prv).companies().setData(value);
+        const response1 = await query1.insertAsync();
+        const url1 = prv.options.url;
+        const expectedUrl1 = "api/Companies";
+        expect(url1).equal(expectedUrl1);
+        expect(prv.options.method).equal("POST");
+        expect(prv.options.data).equal(value);
+        expect(response1).to.deep.equal(value);
+    });
+
+    it("should handle deleteAsync", async () => {
+        const prv = new MockRequestProvider();
+        const query1 = new CompanyService(prv).companies().byKey(5);
+        const response1 = await query1.deleteAsync();
+        const url1 = prv.options.url;
+        const expectedUrl1 = "api/Companies(5)";
+        expect(url1).equal(expectedUrl1);
+        expect(prv.options.method).equal("DELETE");
+        expect(response1).to.be.null; // .undefined ??
+    });
+
 });

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -176,6 +176,16 @@ describe("Service tests", () => {
         expect(url).equal(expectedUrl);
     });
 
+    it("should handle filter parameter with zero value", async () => {
+        const val = 0;
+        const query = service.companies().where("c => c.id >= val", { val });
+        expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+
+        const url = provider.options.url;
+        const expectedUrl = `api/Companies?$filter=${encodeURIComponent("id ge 0")}`;
+        expect(url).equal(expectedUrl);
+    });
+
     it("should handle order and then descending parameters", () => {
         const query = service.companies().orderBy((c) => c.id).thenByDescending((c) => c.name);
         expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
@@ -407,6 +417,16 @@ describe("Service tests", () => {
         expect(query.toString()).equal(expectedQuery);
     });
 
+    it("should handle chained filters", async () => {
+        const query = service.companies().where(c => c.id >= 27).where(c => c.name.startsWith("Net"));
+        expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+
+        const url = provider.options.url;
+        const expectedPrm = "id ge 27 and startswith(name,'Net')";
+        const expectedUrl = `api/Companies?$filter=${encodeURIComponent(expectedPrm)}`;
+        expect(url).equal(expectedUrl);
+    });
+
     it("should handle cast", async () => {
         const prv = new MockRequestProvider(getCompanies());
         const svc = new ODataService("api", prv);
@@ -477,7 +497,7 @@ describe("Service tests", () => {
         const expectedUrl2 = "api/Companies('id5')";
         expect(url2).equal(expectedUrl2);
     });
-    
+
     it("should handle byKey({composite})", async () => {
         const query1 = service.companies().byKey({ id: 7, name: "Microsoft" });
         expect(query1.singleAsync()).to.be.fulfilled.and.eventually.be.null;
@@ -485,7 +505,7 @@ describe("Service tests", () => {
         const expectedUrl1 = "api/Companies(id=7,name='Microsoft')";
         expect(url1).equal(expectedUrl1);
     });
-    
+
     it("should throw for invalid composite key", async () => {
         const query2 = service.companies().byKey({ id: 7 });
         expect(() => query2.singleAsync()).to.throw();

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -550,4 +550,18 @@ it("should handle date literal", async () => {
         const query2 = service.companies().byKey({ id: 7 });
         expect(() => query2.singleAsync()).to.throw();
     });
+
+    it("should handle updateAsync", async () => {
+        const value = getCompany();
+        const result = Object.assign({}, value);
+        const prv = new MockRequestProvider(result);
+        const query1 = new CompanyService(prv).companies().byKey(5);
+        const response1 = await query1.updateAsync(value);
+        const url1 = prv.options.url;
+        const expectedUrl1 = "api/Companies(5)";
+        expect(url1).equal(expectedUrl1);
+        expect(prv.options.method).equal("PUT");
+        expect(response1).to.deep.equal(value);
+    });
+
 });

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -398,7 +398,30 @@ describe("Service tests", () => {
         expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
 
         const url = provider.options.url;
-        const expectedPrm = `createDate lt datetime'${date.toISOString()}' and name ne null`;
+        const expectedPrm = `createDate lt ${date.toISOString()} and name ne null`;
+        const expectedUrl = `api/Companies?$filter=${encodeURIComponent(expectedPrm)}`;
+        expect(url).equal(expectedUrl);
+    });
+
+it("should handle date member func", async () => {
+    const date = new Date(1592, 2, 14);
+    const query = service.companies().where("(c) => c.createDate.getDatePart() >= date", { date });
+    expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+
+    const url = provider.options.url;
+    const expectedPrm = `date(createDate) ge ${date.toISOString()}`;
+    const expectedUrl = `api/Companies?$filter=${encodeURIComponent(expectedPrm)}`;
+    expect(url).equal(expectedUrl);
+});
+
+it("should handle date literal", async () => {
+        const date = new Date(1592, 2, 14);
+        const literal = `Date('${date.toISOString()}')`;
+        const query = service.companies().where(`createDate == ${literal}`);
+        expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+
+        const url = provider.options.url;
+        const expectedPrm = `createDate eq ${date.toISOString()}`;
         const expectedUrl = `api/Companies?$filter=${encodeURIComponent(expectedPrm)}`;
         expect(url).equal(expectedUrl);
     });
@@ -478,6 +501,16 @@ describe("Service tests", () => {
     });
 
     it('should handle boolean parameters', () => {
+        const query = service.companies()
+            .where('c => c.deleted === boolVar', { boolVar: false });
+        expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
+
+        const url = provider.options.url;
+        const expectedUrl = `api/Companies?$filter=${encodeURIComponent("deleted eq false")}`;
+        expect(url).equal(expectedUrl);
+    });
+
+    it('should handle Date parameters', () => {
         const query = service.companies()
             .where('c => c.deleted === boolVar', { boolVar: false });
         expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;


### PR DESCRIPTION
Chain several ODataQuery 'where' clauses with AND into a single predicate

## Change list
- filtering by parameters that have number value equal to zero
- conjunction of several 'where' predicates into a single $filter predicate

## Types of changes

What types of changes are you proposing/introducing?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

1. Fixes [issue #47](https://github.com/jin-qu/jinqu-odata/issues/47)
2. Fixes [issue #48](https://github.com/jin-qu/jinqu-odata/issues/48)