### PR TITLE
NPM build and publish Github Actions workflow added

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish to NPM
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies and build 🔧
+        run: npm install --force && npm run build
+      - name: Publish package on NPM 📦
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "files": [
     "dist",
+    "lib",
     "index.ts",
     "README.md"
   ],


### PR DESCRIPTION
## Change list
Added NPM create and publish Github Actions workflow. NPM package is out of date. It is necessary to add the NPM token as the repository secret key (key: NPM_TOKEN). For more details:
![image](https://github.com/jin-qu/jinqu-odata/assets/7990795/13fba073-3e54-4839-b8a0-c5321a13142e)
![image](https://github.com/jin-qu/jinqu-odata/assets/7990795/863c929b-105e-4e3d-9939-c79b6a58c586)

*Please provide briefly described change list which are you going to propose.*
 
## Types of changes
- Added NPM create and publish Github Actions workflow.
What types of changes are you proposing/introducing?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

1. Fixes #60
